### PR TITLE
Fix Transparent GIFs

### DIFF
--- a/index.js
+++ b/index.js
@@ -415,6 +415,9 @@ AFRAME.registerShader('gif', {
   __draw () {
     if(this.__frameIdx != 0){
       var lastFrame = this.__frames[this.__frameIdx -1 ]
+      // Disposal method indicates if you should clear or not the background.
+      // This flag is represented in binary and is a packed field which can also represent transparency.
+      // http://matthewflickinger.com/lab/whatsinagif/animation_and_transparency.asp  
       if(lastFrame.disposalMethod == 8 || lastFrame.disposalMethod == 9){
         this.__clearCanvas();
       }

--- a/lib/gifsparser.js
+++ b/lib/gifsparser.js
@@ -33,7 +33,11 @@ exports.parseGIF = function (gif, successCB, errorCB) {
         pos += 1 + (+!!(gif[pos] & 0x80) * (Math.pow(2, (gif[pos] & 0x07) + 1) * 3));
         while (gif[++pos]) pos += gif[pos];
         var imageData = gif.subarray(offset, pos + 1);
+        // Each frame should have an image and a flag to indicate how to dispose it.
         var frame = {
+          // http://matthewflickinger.com/lab/whatsinagif/animation_and_transparency.asp
+          // Disposal method is a flag stored in the 3rd byte of the graphics control
+          // This byte is packed and stores more information, only 3 bits of it represent the disposal
           disposalMethod: graphicControl[3],
           blob:URL.createObjectURL(new Blob([gifHeader, graphicControl, imageData]))
         }
@@ -60,6 +64,7 @@ exports.parseGIF = function (gif, successCB, errorCB) {
             imageFix(1);
           }
         }.bind(img, null, i);
+        // Link html image tag with the extracted GIF Frame 
         img.src = frames[i].blob;
         img.disposalMethod = frames[i].disposalMethod;
       }


### PR DESCRIPTION
I've been using your GIF component on a application, after some time studying GIFs and Decoders i found what has been bugging this feature.  
http://matthewflickinger.com/lab/whatsinagif/animation_and_transparency.asp  
Studying this awesome article i discovered that your GIF decoder wasn't returning the Disposal method for each frame. They indicate if you should clean or not your canvas after drawing a frame, this solves the transparency issue, as some GIFs do not store each frame completely, just the pixels that are different from the last frame, so in this case you should not always clean your canvas, it depends on the disposal method flag that is stored inside each graphic control unit.