### PR TITLE
To solve showing all frames issue.

### DIFF
--- a/index.js
+++ b/index.js
@@ -385,6 +385,7 @@ AFRAME.registerShader('gif', {
    * @public
    */
   nextFrame () {
+    this.__clearCanvas ()
     this.__draw()
 
     /* update next frame time */


### PR DESCRIPTION
adding this.__clearCanvas(); before draw in NextCanvas(); to solve showing all frames issue.